### PR TITLE
[feat] SecurityConfig 생성

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,6 +26,9 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/ttogal/api/controller/auth/AuthController.java
+++ b/backend/src/main/java/com/ttogal/api/controller/auth/AuthController.java
@@ -1,0 +1,9 @@
+package com.ttogal.api.controller.auth;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+}

--- a/backend/src/main/java/com/ttogal/api/controller/user/UserController.java
+++ b/backend/src/main/java/com/ttogal/api/controller/user/UserController.java
@@ -1,4 +1,12 @@
 package com.ttogal.api.controller.user;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
 public class UserController {
+
 }

--- a/backend/src/main/java/com/ttogal/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ttogal/common/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+package com.ttogal.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  @Bean
+  public BCryptPasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+  @Bean
+  public SecurityFilterChain configure(HttpSecurity http) throws Exception {
+    http
+            .csrf((auth)->auth.disable());
+    http
+            .formLogin((auth)->auth.disable());
+    http
+            .httpBasic((auth)->auth.disable());
+    http
+            .authorizeHttpRequests((auth)->auth
+                    .requestMatchers("/login","/","/register").permitAll()
+                    .requestMatchers("/admin").hasRole("ADMIN")
+                    .anyRequest().authenticated());
+    http
+            .sessionManagement((session) -> session
+                    .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+    return http.build();
+  }
+}

--- a/backend/src/main/java/com/ttogal/domain/user/entity/constant/UserStatus.java
+++ b/backend/src/main/java/com/ttogal/domain/user/entity/constant/UserStatus.java
@@ -1,0 +1,4 @@
+package com.ttogal.domain.user.entity.constant;
+
+public enum UserStatus {
+}


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #2 

## 📌 작업 사항 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
SpringSecurity를 위한 설정 클래스인 SecurityConfig클래스를 생성한다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. 인증 및 보안 구현을 위한 의존성 추가
 2.  SecurityConfig클래스 생성
 3. SpringSecurity에서 기본 제공 필터 중 jwt 구현에 불필요한 필터는 disable 처리
 4. 접근 권한 설정( Admin, User 권한으로 나누고 로그인과 회원가입을 위한 경로는 모두 접근할 수 있도록 설정)
 5. password 인코딩하는 클래스 빈 등록
 이외 이메일 인증 및 유저 회원가입을 위해 필요한 기본 패키지 및 클래스 파일 생성(UserController, AuthController, UserStatus)


## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
 User 엔티티는 다음 이슈에서 회원가입 로직 구현할 때 개발할 예정입니다. 현재는 아직 User Entity 미구현으로 인해 테이블 생성오류 떠서 실행 안되니 참고해주세요