### PR TITLE
[feat] User 관련 Swagger 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ gradle-wrapper.properties
 *.yaml
 *.yml
 *.sql
+
+# Ignore .env file
+.env

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -24,26 +24,41 @@ repositories {
 }
 
 dependencies {
+    // Spring Boot Starter Dependencies
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    // JSON Web Token (JWT) Dependencies
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    // Lombok Dependencies
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // Database Dependencies
+    runtimeOnly 'com.h2database:h2'
+
+    // Swagger Dependency
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    // Redis Dependency
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    //Spring-Dotenv
+    implementation 'me.paulschwarz:spring-dotenv:2.5.4'
+
+
+    // Test Dependencies
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-    //redis
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis' // Spring Data Redis
-
 }
+
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/backend/src/main/java/com/ttogal/api/controller/email/EmailController.java
+++ b/backend/src/main/java/com/ttogal/api/controller/email/EmailController.java
@@ -3,6 +3,11 @@ package com.ttogal.api.controller.email;
 import com.ttogal.api.service.email.EmailService;
 import com.ttogal.api.controller.email.dto.request.EmailRequestDto;
 import com.ttogal.api.controller.email.dto.request.VerifyCodeRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,20 +19,48 @@ import org.springframework.web.bind.annotation.*;
 public class EmailController {
     private final EmailService emailService;
 
+    @Operation(
+            summary = "이메일 인증 코드 발송",
+            description = "사용자가 제공한 이메일 주소로 인증 코드를 전송합니다.",
+            tags = { "Email" }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "인증 코드 전송 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 이메일 주소"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
     @PostMapping("/send")
-    public ResponseEntity<String> emailCheck(@RequestBody EmailRequestDto request) {
-        String simpleMessage=emailService.sendSimpleMessage(request.getEmail());
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(simpleMessage);
+    public ResponseEntity<String> emailCheck(
+            @RequestBody @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "인증 코드를 보낼 이메일 주소",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = EmailRequestDto.class))
+            ) EmailRequestDto request) {
+        String simpleMessage = emailService.sendSimpleMessage(request.getEmail());
+        return ResponseEntity.status(HttpStatus.OK).body(simpleMessage);
     }
 
-    // 인증코드 인증
+    @Operation(
+            summary = "인증 코드 검증",
+            description = "사용자가 제공한 이메일과 인증 코드를 검증합니다.",
+            tags = { "Email" }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "인증 코드 검증 성공",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "잘못된 인증 코드 또는 이메일",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(mediaType = "application/json"))
+    })
     @PostMapping("/verify")
-    public ResponseEntity<Boolean> verify(@RequestBody VerifyCodeRequestDto request) {
-        Boolean isVerified=emailService.verifyEmailCode(request.getEmail(), request.getAuthCode());
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(isVerified);
+    public ResponseEntity<Boolean> verify(
+            @RequestBody @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "이메일과 인증 코드를 포함하는 요청 본문",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = VerifyCodeRequestDto.class))
+            ) VerifyCodeRequestDto request) {
+        Boolean isVerified = emailService.verifyEmailCode(request.getEmail(), request.getAuthCode());
+        return ResponseEntity.status(HttpStatus.OK).body(isVerified);
     }
-
-
 }

--- a/backend/src/main/java/com/ttogal/api/controller/email/dto/request/EmailRequestDto.java
+++ b/backend/src/main/java/com/ttogal/api/controller/email/dto/request/EmailRequestDto.java
@@ -1,5 +1,6 @@
 package com.ttogal.api.controller.email.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
@@ -13,6 +14,7 @@ public class EmailRequestDto {
 
     @Email
     @NotEmpty
+    @Schema(description = "인증 코드를 보낼 이메일 주소", example = "example@naver.com")
     private String email;
 
 }

--- a/backend/src/main/java/com/ttogal/api/controller/email/dto/request/VerifyCodeRequestDto.java
+++ b/backend/src/main/java/com/ttogal/api/controller/email/dto/request/VerifyCodeRequestDto.java
@@ -1,5 +1,6 @@
 package com.ttogal.api.controller.email.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
@@ -8,9 +9,11 @@ import lombok.Data;
 public class VerifyCodeRequestDto {
 
     @Email
+    @Schema(description = "인증을 진행할 이메일 주소", example = "example@naver.com")
     private String email;
 
     @NotBlank
+    @Schema(description = "사용자가 입력한 인증 코드", example = "123456")
     private String authCode;
 
 }

--- a/backend/src/main/java/com/ttogal/api/controller/user/UserController.java
+++ b/backend/src/main/java/com/ttogal/api/controller/user/UserController.java
@@ -2,6 +2,7 @@ package com.ttogal.api.controller.user;
 
 import com.ttogal.api.controller.user.dto.request.UserRegisterRequestDto;
 import com.ttogal.api.controller.user.dto.request.ValidateEmailRequestDto;
+import com.ttogal.api.controller.user.dto.request.ValidateNicknameRequestDto;
 import com.ttogal.api.controller.user.dto.response.UserRegisterResponseDto;
 import com.ttogal.api.controller.user.dto.response.UserResponseDto;
 import com.ttogal.api.service.user.UserService;
@@ -15,32 +16,64 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
+@Tag(name = "User API", description = "사용자 관련 API")
 public class UserController {
+
   private final UserService userService;
   private final UserResponseHandler userResponseHandler;
 
   @PostMapping("/register")
-  public ResponseEntity<UserRegisterResponseDto> register(@RequestBody @Valid UserRegisterRequestDto dto) {
+  @Operation(
+          summary = "회원가입",
+          description = "새로운 사용자를 등록합니다.",
+          responses = {
+                  @ApiResponse(responseCode = "200",description = "회원가입 성공"),
+                  @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터")
+          }
+  )
+  public ResponseEntity<UserRegisterResponseDto> register(
+          @RequestBody @Valid UserRegisterRequestDto dto) {
     Long userId = userService.register(dto);
     UserRegisterResponseDto responseDto = userResponseHandler.createRegisterResponse(userId);
-    return new ResponseEntity<>(responseDto,HttpStatus.OK);
+    return new ResponseEntity<>(responseDto, HttpStatus.OK);
   }
 
   @PostMapping("/validate-email")
-  public ResponseEntity<UserResponseDto> validateEmail(@RequestBody @Valid ValidateEmailRequestDto requestdto) {
-    userService.validateEmail(requestdto.email());
-    UserResponseDto responseDto=UserResponseDto.builder().message("이메일 검증이 완료되었습니다.").build();
-    return new ResponseEntity<>(responseDto,HttpStatus.OK);
+  @Operation(
+          summary = "이메일 유효성 검증",
+          description = "사용자가 입력한 이메일의 유효성을 검증합니다.",
+          responses = {
+                  @ApiResponse(responseCode = "200",description = "이메일 검증 성공"),
+                  @ApiResponse(responseCode = "400",description = "잘못된 이메일 형식")
+          }
+  )
+  public ResponseEntity<UserResponseDto> validateEmail(
+          @RequestBody @Valid ValidateEmailRequestDto requestDto) {
+    userService.validateEmail(requestDto.email());
+    UserResponseDto responseDto = userResponseHandler.createUserResponse("이메일 검증이 완료되었습니다.");
+    return new ResponseEntity<>(responseDto, HttpStatus.OK);
   }
 
   @PostMapping("/validate-nickname")
-  public ResponseEntity<UserResponseDto> validateNickname(@RequestBody @Valid UserRegisterRequestDto requestdto) {
-    userService.validateNickname(requestdto.nickname());
-    UserResponseDto responseDto=UserResponseDto.builder().message("닉네임 검증이 완료되었습니다.").build();
-    return new ResponseEntity<>(responseDto,HttpStatus.OK);
-
+  @Operation(
+          summary = "닉네임 유효성 검증",
+          description = "사용자가 입력한 닉네임의 유효성을 검증합니다.",
+          responses = {
+                  @ApiResponse(responseCode = "200",description = "닉네임 검증 성공"),
+                  @ApiResponse(responseCode = "400",description = "잘못된 닉네임 형식")
+          }
+  )
+  public ResponseEntity<UserResponseDto> validateNickname(
+          @RequestBody @Valid ValidateNicknameRequestDto requestDto) {
+    userService.validateNickname(requestDto.nickname());
+    UserResponseDto responseDto = userResponseHandler.createUserResponse("사용가능한 닉네임입니다.");
+    return new ResponseEntity<>(responseDto, HttpStatus.OK);
   }
 }

--- a/backend/src/main/java/com/ttogal/api/controller/user/dto/request/UserRegisterRequestDto.java
+++ b/backend/src/main/java/com/ttogal/api/controller/user/dto/request/UserRegisterRequestDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.ttogal.domain.user.entity.User;
 import com.ttogal.domain.user.entity.constant.Gender;
 import com.ttogal.domain.user.entity.constant.JobStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.Builder;
 
@@ -13,31 +14,38 @@ import java.time.LocalDate;
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record UserRegisterRequestDto(
+        @Schema(description = "사용자의 이름", example = "홍길동")
         @NotNull(message = "이름을 입력해주세요.")
         String name,
 
+        @Schema(description = "사용자의 이메일 주소", example = "example@naver.com")
         @Email
         @NotNull(message = "이메일 주소를 입력해주세요.")
         String email,
 
+        @Schema(description = "사용자의 닉네임 (2~12자)", example = "길동이")
         @NotNull(message = "닉네임을 입력해주세요.")
         @Size(min = 2, max = 12, message = "닉네임은 2자 이상 12자 이내로 입력해주세요.")
         @Pattern(regexp = "^[^\\s]*$", message = "닉네임은 공백 없이 입력해주세요.")
         String nickname,
 
+        @Schema(description = "비밀번호 (최소 8자, 영문/숫자/특수문자 중 2가지 이상 조합)",example = "Password123")
         @NotNull(message = "비밀번호를 입력해주세요")
         @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
         @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@#$%^&+=!])|(?=.*[a-zA-Z])(?=.*\\d)(?=.*[^a-zA-Z\\d])|(?=.*[a-zA-Z])(?=.*[@#$%^&+=!])(?=.*\\d)|(?=.*\\d)(?=.*[@#$%^&+=!])(?=.*[a-zA-Z]).*$",
                 message = "영문 대소문자, 숫자, 특수문자 중 2가지 이상 조합/공백 불가")
         String password,
 
+        @Schema(description = "현재 재직 상태 (예: STUDENT, EMPLOYEE, FREELANCER, JOB_SEEKING, ENTREPRENEUR, ON_LEAVE, OTHERS)", example = "JOB_SEEKING")
         @NotNull(message = "현재 재직 상태를 입력해주세요.")
         JobStatus jobStatus,
 
+        @Schema(description = "생년월일 (yyyy-MM-dd 형식)", example = "2001-01-01")
         @NotNull(message = "생년월일을 yyyy-MM-dd 형식으로 입력해주세요.")
         @Past
         LocalDate birthDate,
 
+        @Schema(description = "성별 (예: MALE, FEMALE)", example = "MALE")
         @NotNull(message = "성별을 선택해주세요.")
         Gender gender
 ) {

--- a/backend/src/main/java/com/ttogal/api/controller/user/dto/request/ValidateEmailRequestDto.java
+++ b/backend/src/main/java/com/ttogal/api/controller/user/dto/request/ValidateEmailRequestDto.java
@@ -1,11 +1,13 @@
 package com.ttogal.api.controller.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 public record ValidateEmailRequestDto(
+        @Schema(description = "사용자의 이메일 주소", example = "example@naver.com")
         @NotNull(message = "이메일 주소를 입력해주세요.")
         @Email(message = "유효한 이메일 형식이 아닙니다.")
         String email

--- a/backend/src/main/java/com/ttogal/api/controller/user/dto/request/ValidateNicknameRequestDto.java
+++ b/backend/src/main/java/com/ttogal/api/controller/user/dto/request/ValidateNicknameRequestDto.java
@@ -1,6 +1,7 @@
 package com.ttogal.api.controller.user.dto.request;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -8,6 +9,7 @@ import lombok.Builder;
 
 @Builder
 public record ValidateNicknameRequestDto(
+        @Schema(description = "사용자의 닉네임 (2~12자)", example = "길동이")
         @NotNull(message = "닉네임을 입력해주세요.")
         @Size(min = 2, max = 12, message = "닉네임은 2자 이상 12자 이내로 입력해주세요.")
         @Pattern(regexp = "^[^\\s]*$", message = "닉네임은 공백 없이 입력해주세요.")

--- a/backend/src/main/java/com/ttogal/api/service/user/UserService.java
+++ b/backend/src/main/java/com/ttogal/api/service/user/UserService.java
@@ -1,9 +1,6 @@
 package com.ttogal.api.service.user;
 
 import com.ttogal.api.controller.user.dto.request.UserRegisterRequestDto;
-import com.ttogal.api.controller.user.dto.request.ValidateEmailRequestDto;
-import com.ttogal.api.controller.user.dto.response.UserRegisterResponseDto;
-import com.ttogal.api.controller.user.dto.response.UserResponseDto;
 import com.ttogal.common.exception.ExceptionCode;
 import com.ttogal.common.exception.user.UserException;
 import com.ttogal.domain.user.entity.User;

--- a/backend/src/main/java/com/ttogal/common/config/EmailConfig.java
+++ b/backend/src/main/java/com/ttogal/common/config/EmailConfig.java
@@ -23,14 +23,12 @@ public class EmailConfig {
     @Value("${mail.password}")
     private String password;
 
-    @Value("${mail.properties.mail.smtp.auth}")
-    private boolean auth;
 
-    @Value("${mail.properties.mail.smtp.starttls.enable}")
-    private boolean starttlsEnable;
+//    @Value("${mail.properties.mail.smtp.starttls.enable}")
+//    private boolean starttlsEnable;
 
-    @Value("${mail.properties.mail.smtp.starttls.required}")
-    private boolean starttlsRequired;
+//    @Value("${mail.properties.mail.smtp.starttls.required}")
+//    private boolean starttlsRequired;
 
     @Value("${mail.properties.mail.smtp.connectiontimeout}")
     private int connectionTimeout;
@@ -54,22 +52,18 @@ public class EmailConfig {
         mailSender.setJavaMailProperties(getMailProperties());
 
         Properties props = mailSender.getJavaMailProperties();
-        props.put("mail.transport.protocol", "smtp");
-        props.put("mail.smtp.auth", "true");
-        props.put("mail.smtp.starttls.enable", "true");
-        props.put("mail.debug", "true");
-
-        return mailSender;
+               return mailSender;
     }
 
     private Properties getMailProperties() {
         Properties properties = new Properties();
-        properties.put("mail.smtp.auth", auth);
-        properties.put("mail.smtp.starttls.enable", starttlsEnable);
-        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.transport.protocol", "smtp");
+        properties.put("mail.smtp.auth", "true");
+        properties.put("mail.smtp.ssl.enable", "true"); // SSL 활성화
         properties.put("mail.smtp.connectiontimeout", connectionTimeout);
         properties.put("mail.smtp.timeout", timeout);
         properties.put("mail.smtp.writetimeout", writeTimeout);
+        properties.put("mail.debug", "true");
 
         return properties;
     }

--- a/backend/src/main/java/com/ttogal/common/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/ttogal/common/config/SwaggerConfig.java
@@ -1,0 +1,55 @@
+package com.ttogal.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+  @Bean
+  public OpenAPI customOpenAPI() {
+    return new OpenAPI()
+            .info(new Info()
+                    .title("springdoc-openapi")
+                    .version("1.0")
+                    .description("Ttogal swagger-ui 화면입니다")
+            )
+            .components(new Components()
+                    .addSecuritySchemes("bearer-jwt",
+                            new SecurityScheme()
+                                    .type(SecurityScheme.Type.HTTP)
+                                    .scheme("bearer")
+                                    .bearerFormat("JWT")))
+            .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"));
+
+  }
+
+  @Bean
+  public GroupedOpenApi getAllAPI() {
+    return GroupedOpenApi.builder()
+            .group("all")
+            .pathsToMatch("/api/v1/**")
+            .build();
+  }
+
+  @Bean
+  public GroupedOpenApi getUserApi(){
+    return GroupedOpenApi.builder()
+            .group("user")
+            .pathsToMatch("/api/v1/users/**")
+            .build();
+  }
+
+  @Bean
+  public GroupedOpenApi getEmailApi(){
+    return GroupedOpenApi.builder()
+            .group("email")
+            .pathsToMatch("/api/v1/email/**")
+            .build();
+  }
+}

--- a/backend/src/main/java/com/ttogal/common/handler/user/UserResponseHandler.java
+++ b/backend/src/main/java/com/ttogal/common/handler/user/UserResponseHandler.java
@@ -1,6 +1,7 @@
 package com.ttogal.common.handler.user;
 
 import com.ttogal.api.controller.user.dto.response.UserRegisterResponseDto;
+import com.ttogal.api.controller.user.dto.response.UserResponseDto;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,6 +12,10 @@ public class UserResponseHandler {
                 .userId(userId)
                 .message("회원가입이 성공적으로 완료되었습니다.")
                 .build();
+    }
+
+    public UserResponseDto createUserResponse(String message) {
+        return UserResponseDto.builder().message(message).build();
     }
 
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,0 +1,32 @@
+spring:
+  datasource:
+    url: jdbc:h2:file:~/testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    hibernate:
+      ddl-auto: validate
+
+mail:
+  host: ${MAIL_HOST}              # SMTP 서버 주소
+  port: ${MAIL_PORT}              # SMTP 서버 포트
+  username: ${MAIL_USERNAME}      # 이메일 사용자 계정
+  password: ${MAIL_PASSWORD}      # 이메일 사용자 비밀번호
+  sender-email: ${MAIL_SENDER_EMAIL} # 사용자 이메일 주소
+
+  properties:
+    mail:
+      smtp:
+        connectiontimeout: ${MAIL_CONNECTIONTIMEOUT} # SMTP 연결 타임아웃 (밀리초 단위)
+        timeout: ${MAIL_TIMEOUT}                     # SMTP 응답 타임아웃 (밀리초 단위)
+        writetimeout: ${MAIL_WRITETIMEOUT}           # SMTP 쓰기 타임아웃 (밀리초 단위)
+
+  data:
+    redis:
+      host: ${REDIS_HOST}         # Redis 서버 호스트
+      port: ${REDIS_PORT}         # Redis 서버 포트


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #15 

## 📌 작업 사항 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
1. User 관련 Dto에 swagger 적용
2. UserController에 swagger 적용
3. Email 관련 Dto에 swagger 적용
4. EmailController에 swagger 적용
5. .env 파일에 보안에 민감한 데이터 작성
6. application.yaml 에 환경변수 코드 추가
7. build.gradle에 swagger, dotenv, redis 관련 의존성 추가
8. SecurityConfig에 필터 통과시킬 예외 경로 설정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
Commit 별로 상세하게 설명해두었으니, 확인하시고 궁금하신 점 말씀해주세요!

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 이메일 서버 관련
네이버 메일 서버의 암호화 방식( TLS와 SSL)  중 SSL 이용을 위해 SMTP 서버 포트번호 465로 지정하였습니다. 
암호화 방식으로 TLS 방식보다 SSL방식을 많이들 이용한다고 해서, SSL을 활성화하는 코드(properties.put("mail.smtp.ssl.enable", "true"))를 EmailConfig 에 추가하고, 기존에 있던 TLS 활성화 코드는 주석 처리하였습니다. 확인 부탁드립니다. 

- 테스트 관련
정상적으로 실행되고, swagger로 현재까지 구현한 api들이 의도한대로 동작하는지 간단하게 테스트 완료했습니다. 