### PR TITLE
[feat] 스프링 시큐리티+JWT를 이용한 로그인 로직 구현

### DIFF
--- a/backend/src/main/java/com/ttogal/api/controller/user/UserController.java
+++ b/backend/src/main/java/com/ttogal/api/controller/user/UserController.java
@@ -1,5 +1,6 @@
 package com.ttogal.api.controller.user;
 
+import com.ttogal.api.controller.user.dto.request.LoginRequestDto;
 import com.ttogal.api.controller.user.dto.request.UserRegisterRequestDto;
 import com.ttogal.api.controller.user.dto.request.ValidateEmailRequestDto;
 import com.ttogal.api.controller.user.dto.request.ValidateNicknameRequestDto;
@@ -28,6 +29,19 @@ public class UserController {
 
   private final UserService userService;
   private final UserResponseHandler userResponseHandler;
+
+  @PostMapping("/login")
+  @Operation(
+          summary = "로그인",
+          description = "이메일과 비밀번호로 사용자를 인증합니다.",
+          responses = {
+                  @ApiResponse(responseCode = "200",description = "로그인 성공"),
+                  @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터")
+          }
+  )
+  public void login(@RequestBody @Valid LoginRequestDto loginRequestDto) {
+  }
+
 
   @PostMapping("/register")
   @Operation(

--- a/backend/src/main/java/com/ttogal/api/controller/user/dto/request/LoginRequestDto.java
+++ b/backend/src/main/java/com/ttogal/api/controller/user/dto/request/LoginRequestDto.java
@@ -1,0 +1,19 @@
+package com.ttogal.api.controller.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+
+@Builder
+public record LoginRequestDto(
+        @Schema(description = "사용자의 이메일 주소", example = "example@naver.com")
+        @NotBlank(message = "이메일 주소를 입력해주세요.")
+        @Email(message = "유효한 이메일 형식이 아닙니다.")
+        String email,
+
+        @Schema(description = "비밀번호 (최소 8자, 영문/숫자/특수문자 중 2가지 이상 조합)",example = "asdf1234!")
+        @NotBlank(message = "비밀번호를 입력해주세요")
+        @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+        String password
+) {
+}

--- a/backend/src/main/java/com/ttogal/api/controller/user/dto/request/UserRegisterRequestDto.java
+++ b/backend/src/main/java/com/ttogal/api/controller/user/dto/request/UserRegisterRequestDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.ttogal.domain.user.entity.User;
 import com.ttogal.domain.user.entity.constant.Gender;
 import com.ttogal.domain.user.entity.constant.JobStatus;
+import com.ttogal.domain.user.entity.constant.Role;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.Builder;
@@ -58,6 +59,7 @@ public record UserRegisterRequestDto(
             .jobStatus(this.jobStatus)
             .birthDate(this.birthDate)
             .gender(this.gender)
+            .role(Role.USER)
             .build();
   }
 }

--- a/backend/src/main/java/com/ttogal/api/controller/user/dto/request/ValidateEmailRequestDto.java
+++ b/backend/src/main/java/com/ttogal/api/controller/user/dto/request/ValidateEmailRequestDto.java
@@ -2,13 +2,13 @@ package com.ttogal.api.controller.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
 public record ValidateEmailRequestDto(
         @Schema(description = "사용자의 이메일 주소", example = "example@naver.com")
-        @NotNull(message = "이메일 주소를 입력해주세요.")
+        @NotBlank(message = "이메일 주소를 입력해주세요.")
         @Email(message = "유효한 이메일 형식이 아닙니다.")
         String email
 ) {

--- a/backend/src/main/java/com/ttogal/api/controller/user/dto/response/CustomUserDetails.java
+++ b/backend/src/main/java/com/ttogal/api/controller/user/dto/response/CustomUserDetails.java
@@ -1,0 +1,57 @@
+package com.ttogal.api.controller.user.dto.response;
+
+import com.ttogal.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+  private final User user;
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    Collection<GrantedAuthority>collection=new ArrayList<>();
+    collection.add(new GrantedAuthority() {
+      @Override
+      public String getAuthority() {
+        return user.getRole().toString();
+      }
+    });
+    return List.of();
+  }
+
+  @Override
+  public String getPassword() {
+    return user.getPassword();
+  }
+
+  @Override
+  public String getUsername() {
+    return user.getEmail();
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return UserDetails.super.isAccountNonExpired();
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return UserDetails.super.isAccountNonLocked();
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return UserDetails.super.isCredentialsNonExpired();
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return UserDetails.super.isEnabled();
+  }
+}

--- a/backend/src/main/java/com/ttogal/api/service/user/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/ttogal/api/service/user/CustomUserDetailsService.java
@@ -1,0 +1,23 @@
+package com.ttogal.api.service.user;
+
+import com.ttogal.api.controller.user.dto.response.CustomUserDetails;
+import com.ttogal.domain.user.entity.User;
+import com.ttogal.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+  private final UserRepository userRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    User user=userRepository.findByEmail(username).orElseThrow(
+            ()->new UsernameNotFoundException("해당 사용자가 존재하지 않습니다."));
+    return new CustomUserDetails(user);
+  }
+}

--- a/backend/src/main/java/com/ttogal/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ttogal/common/config/SecurityConfig.java
@@ -1,18 +1,29 @@
 package com.ttogal.common.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ttogal.api.service.user.CustomUserDetailsService;
+import com.ttogal.common.filter.LoginFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.*;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final CustomUserDetailsService customUserDetailsService;
+  private final ObjectMapper objectMapper;
 
   @Bean
   public BCryptPasswordEncoder passwordEncoder() {
@@ -36,15 +47,33 @@ public class SecurityConfig {
                             .requestMatchers("/static/**", "/templates/**").permitAll()
                             .requestMatchers("/h2-console/**").permitAll()
                             //user
-                            .requestMatchers("/login","/api/v1/users/register").permitAll()
+                            .requestMatchers("/login", "/api/v1/users/register").permitAll()
                             .requestMatchers("/api/v1/users").authenticated()
                             //email
-                            .requestMatchers( "/api/v1/email/**").permitAll()
+                            .requestMatchers("/api/v1/email/**").permitAll()
                             //admin
                             .requestMatchers("/admin").hasRole("ADMIN")
                             .anyRequest().permitAll()
-            );
+            )
+            .addFilterAt(loginAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
     return http.build();
   }
 
+
+  @Bean
+  public AuthenticationManager authenticationManager() {
+    DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+    provider.setPasswordEncoder(passwordEncoder());
+    provider.setUserDetailsService(customUserDetailsService);
+    return new ProviderManager(provider);
+  }
+
+
+  @Bean
+  LoginFilter loginAuthenticationFilter() {
+    LoginFilter loginFilter
+            = new LoginFilter(objectMapper);
+    loginFilter.setAuthenticationManager(authenticationManager());
+    return loginFilter;
+  }
 }

--- a/backend/src/main/java/com/ttogal/common/filter/LoginFilter.java
+++ b/backend/src/main/java/com/ttogal/common/filter/LoginFilter.java
@@ -1,0 +1,51 @@
+package com.ttogal.common.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ttogal.api.controller.user.dto.request.LoginRequestDto;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+import java.io.IOException;
+
+
+@Slf4j
+public class LoginFilter extends AbstractAuthenticationProcessingFilter {
+  private final static String REQUEST_URL = "/api/v1/users/login";
+  private final static String HTTP_METHOD = "POST";
+
+  private static final AntPathRequestMatcher PATH_REQUEST_MATCHER = new AntPathRequestMatcher(REQUEST_URL,HTTP_METHOD);
+
+  private final ObjectMapper objectMapper;
+
+  public LoginFilter(ObjectMapper objectMapper) {
+    super(PATH_REQUEST_MATCHER);
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException {
+      LoginRequestDto dto=objectMapper.readValue(request.getInputStream(),
+              LoginRequestDto.class);
+    log.info("인증 시도 유저:{}", dto.email());
+      UsernamePasswordAuthenticationToken authenticationToken=new UsernamePasswordAuthenticationToken(dto.email(), dto.password());
+      return this.getAuthenticationManager().authenticate(authenticationToken);
+  }
+
+  @Override
+  protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+    System.out.println("success");
+  }
+
+  @Override
+  protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
+    System.out.println("fail");
+  }
+}

--- a/backend/src/main/java/com/ttogal/domain/user/entity/User.java
+++ b/backend/src/main/java/com/ttogal/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package com.ttogal.domain.user.entity;
 
 import com.ttogal.domain.user.entity.constant.Gender;
 import com.ttogal.domain.user.entity.constant.JobStatus;
+import com.ttogal.domain.user.entity.constant.Role;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -43,8 +44,12 @@ public class User {
   @Column(nullable=false)
   private Gender gender;
 
+  @Enumerated(EnumType.STRING)
+  @Column(nullable=false)
+  private Role role;
+
   @Builder
-  public User(String name,String email, String nickname, String password, JobStatus jobStatus, LocalDate birthDate, Gender gender) {
+  public User(String name,String email, String nickname, String password, JobStatus jobStatus, LocalDate birthDate, Gender gender,Role role) {
     this.name = name;
     this.email = email;
     this.nickname = nickname;
@@ -52,5 +57,6 @@ public class User {
     this.jobStatus = jobStatus;
     this.birthDate = birthDate;
     this.gender = gender;
+    this.role=role;
   }
 }

--- a/backend/src/main/java/com/ttogal/domain/user/entity/constant/Role.java
+++ b/backend/src/main/java/com/ttogal/domain/user/entity/constant/Role.java
@@ -1,0 +1,12 @@
+package com.ttogal.domain.user.entity.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+  USER("일반 사용자"),
+  ADMIN("관리자");
+  private final String text;
+}

--- a/backend/src/main/java/com/ttogal/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/ttogal/domain/user/repository/UserRepository.java
@@ -4,9 +4,12 @@ import com.ttogal.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
   boolean existsByEmail(String email);
-
   boolean existsByNickname(String nickname);
+
+  Optional<User> findByEmail(String email);
 }

--- a/backend/src/test/java/com/ttogal/BackendApplicationTests.java
+++ b/backend/src/test/java/com/ttogal/BackendApplicationTests.java
@@ -2,12 +2,14 @@ package com.ttogal;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BackendApplicationTests {
 
   @Test
   void contextLoads() {
+    // 테스트 코드
   }
-
 }


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #15 

## 📌 작업 사항 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
 1. 로그인 필터 구현
 2. DB 기반 로그인 검증 로직 구현
![image](https://github.com/user-attachments/assets/a56d37aa-ff9a-4bf5-b30a-21cecbf63475)
![image](https://github.com/user-attachments/assets/b9a35377-21c9-4bbc-8b36-498e7727375c)
![image](https://github.com/user-attachments/assets/8db559b9-e7c7-4827-a23a-9f8e5f40a3dc)

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1.  사용자의 /login 요청을 가로채 로그인 진행하는 시작점인 LoginFilter 구현
2.  DB 기반 유저 조회하는 CustomUserDetailsService 구현
3.  DB에서 조회한 유저 엔티티를 담을 바구니인 CustomUserDetail 개발
4.  UserController에 **/api/v1/users/login 경로의 api 개발**
5. 사용자의 로그인 요청 정보를 담을 LoginRequestDto 개발
6. Role클래스 enum 으로 정의**(USER,ADMIN)**->추후 권한 부여를 위하여 **일반사용자**와 **관리자**로 분류
7. **User Entity 필드에 Role 추가**
8. UserRepository에 이메일로 사용자 조회하는 메소드 구현
9. SecurityConfig에 AuthenticationManager, LoginFilter 빈으로 등록
10. **BackendApplicationTests에 @ActiveProfiles("test") 애노테이션 추가**

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
추후 권한에 따라 api 경로 접근을 제한하기 위해 Users테이블에 role 컬럼을 추가하였습니다. role은 기본적으로 일반사용자와 관리자로 나뉘고, 회원가입 시 일단 **일반사용자**로 저장되도록 구현하였습니다. 


- 테스트 관련
정상적으로 실행되고, swagger로 로그인 api 테스트 완료했습니다. 
