### PR TITLE
[Chore] Test 관련 Failed to load ApplicationContext 에러 해결

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -61,7 +61,6 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'com.h2database:h2' // 테스트용 내장 데이터베이스
-
 }
 
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     // Database Dependencies
     runtimeOnly 'com.h2database:h2' //개발 환경
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'mysql:mysql-connector-java:8.0.27' // 적절한 버전으로 수정
+
 
 
     // Swagger Dependency
@@ -59,6 +61,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'com.h2database:h2' // 테스트용 내장 데이터베이스
+
 }
 
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -43,7 +43,6 @@ dependencies {
     // Database Dependencies
     runtimeOnly 'com.h2database:h2' //개발 환경
     runtimeOnly 'com.mysql:mysql-connector-j'
-    implementation 'mysql:mysql-connector-java:8.0.27' // 적절한 버전으로 수정
 
 
 

--- a/backend/src/test/java/com/ttogal/BackendApplicationTests.java
+++ b/backend/src/test/java/com/ttogal/BackendApplicationTests.java
@@ -2,8 +2,10 @@ package com.ttogal;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BackendApplicationTests {
 
   @Test

--- a/backend/src/test/java/com/ttogal/BackendApplicationTests.java
+++ b/backend/src/test/java/com/ttogal/BackendApplicationTests.java
@@ -5,7 +5,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("test")
 class BackendApplicationTests {
 
   @Test


### PR DESCRIPTION
 ./gradlew clean build시 test부분에서
```
Path for java installation '/usr/lib/jvm/openjdk-17' (Common Linux Locations) does not contain a java executable

1 test completed, 1 failed

> Task :test FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':test'.

which java

/usr/lib/jvm/java-17-openjdk-amd64/bin/java
```
오류가 발생해서 gradle의 경로를 재설정하였지만 이런 trouble 발생하였습니다 그래서 로컬은 되나 돌려보니 오류가 떠서 해결하려고 합니다.
일단 로컬에서의 문제는 해결하였습니다!

