### PR TITLE
[feat] JWT 발급 및 검증 클래스 개발

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -59,6 +59,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Jwt Dependency
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 

--- a/backend/src/main/java/com/ttogal/api/controller/user/UserController.java
+++ b/backend/src/main/java/com/ttogal/api/controller/user/UserController.java
@@ -12,14 +12,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -89,5 +88,11 @@ public class UserController {
     userService.validateNickname(requestDto.nickname());
     UserResponseDto responseDto = userResponseHandler.createUserResponse("사용가능한 닉네임입니다.");
     return new ResponseEntity<>(responseDto, HttpStatus.OK);
+  }
+
+  @GetMapping("/{userId}")
+  public ResponseEntity<Void> getUser(@PathVariable("userId") Long userId){
+    System.out.println("userId: " + userId);
+    return new ResponseEntity<>(HttpStatus.OK);
   }
 }

--- a/backend/src/main/java/com/ttogal/api/controller/user/dto/response/CustomUserDetails.java
+++ b/backend/src/main/java/com/ttogal/api/controller/user/dto/response/CustomUserDetails.java
@@ -22,7 +22,7 @@ public class CustomUserDetails implements UserDetails {
         return user.getRole().toString();
       }
     });
-    return List.of();
+    return collection;
   }
 
   @Override

--- a/backend/src/main/java/com/ttogal/common/filter/JwtFilter.java
+++ b/backend/src/main/java/com/ttogal/common/filter/JwtFilter.java
@@ -1,0 +1,55 @@
+package com.ttogal.common.filter;
+
+import com.ttogal.api.controller.user.dto.response.CustomUserDetails;
+import com.ttogal.common.util.JwtUtil;
+import com.ttogal.domain.user.entity.User;
+import com.ttogal.domain.user.entity.constant.Role;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+  private final JwtUtil jwtUtil;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    String authorization= request.getHeader("Authorization");
+
+  if(authorization==null || !authorization.startsWith("Bearer ")) {
+    System.out.println("token null");
+    filterChain.doFilter(request, response);
+    return;
+  }
+
+  String token = authorization.split(" ")[1];
+
+  if(jwtUtil.isTokenExpired(token)){
+    System.out.println("token expired");
+    filterChain.doFilter(request, response);
+    return;
+  }
+
+  String username = jwtUtil.getUsername(token);
+  String tempPassword="tempPassword";
+  String role = jwtUtil.getRole(token);
+
+  User user=User.builder().email(username)
+          .password(tempPassword)
+          .role(Role.getRole(role))
+          .build();
+
+    CustomUserDetails customUserDetails = new CustomUserDetails(user);
+    Authentication authToken=new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+    SecurityContextHolder.getContext().setAuthentication(authToken);
+    filterChain.doFilter(request, response);
+  }
+}

--- a/backend/src/main/java/com/ttogal/common/filter/JwtFilter.java
+++ b/backend/src/main/java/com/ttogal/common/filter/JwtFilter.java
@@ -44,7 +44,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
   User user=User.builder().email(username)
           .password(tempPassword)
-          .role(Role.getRole(role))
+          .role(Role.valueOf(role.toUpperCase()))
           .build();
 
     CustomUserDetails customUserDetails = new CustomUserDetails(user);

--- a/backend/src/main/java/com/ttogal/common/filter/LoginFilter.java
+++ b/backend/src/main/java/com/ttogal/common/filter/LoginFilter.java
@@ -52,9 +52,9 @@ public class LoginFilter extends AbstractAuthenticationProcessingFilter {
     String role = extractRole(authentication);
 
     String accessToken = jwtUtil.createAccessToken(username, role);
-    String refrestToken = jwtUtil.createRefreshToken(username, role);
+    String refreshToken = jwtUtil.createRefreshToken(username, role);
 
-    jwtUtil.sendAccessAndRefreshToken(response, accessToken, refrestToken);
+    jwtUtil.sendAccessAndRefreshToken(response, accessToken, refreshToken);
 
     log.info("로그인 성공: {}", username);
     log.info("Access & refresh 토큰 생성");

--- a/backend/src/main/java/com/ttogal/common/filter/LoginFilter.java
+++ b/backend/src/main/java/com/ttogal/common/filter/LoginFilter.java
@@ -2,6 +2,8 @@ package com.ttogal.common.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ttogal.api.controller.user.dto.request.LoginRequestDto;
+import com.ttogal.api.controller.user.dto.response.CustomUserDetails;
+import com.ttogal.common.util.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,10 +12,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
 
 
 @Slf4j
@@ -21,31 +26,55 @@ public class LoginFilter extends AbstractAuthenticationProcessingFilter {
   private final static String REQUEST_URL = "/api/v1/users/login";
   private final static String HTTP_METHOD = "POST";
 
-  private static final AntPathRequestMatcher PATH_REQUEST_MATCHER = new AntPathRequestMatcher(REQUEST_URL,HTTP_METHOD);
+  private static final AntPathRequestMatcher PATH_REQUEST_MATCHER = new AntPathRequestMatcher(REQUEST_URL, HTTP_METHOD);
 
   private final ObjectMapper objectMapper;
+  private final JwtUtil jwtUtil;
 
-  public LoginFilter(ObjectMapper objectMapper) {
+  public LoginFilter(ObjectMapper objectMapper, JwtUtil jwtUtil) {
     super(PATH_REQUEST_MATCHER);
     this.objectMapper = objectMapper;
+    this.jwtUtil = jwtUtil;
   }
 
   @Override
   public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException {
-      LoginRequestDto dto=objectMapper.readValue(request.getInputStream(),
-              LoginRequestDto.class);
+    LoginRequestDto dto = objectMapper.readValue(request.getInputStream(),
+            LoginRequestDto.class);
     log.info("인증 시도 유저:{}", dto.email());
-      UsernamePasswordAuthenticationToken authenticationToken=new UsernamePasswordAuthenticationToken(dto.email(), dto.password());
-      return this.getAuthenticationManager().authenticate(authenticationToken);
+    UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(dto.email(), dto.password());
+    return this.getAuthenticationManager().authenticate(authenticationToken);
   }
 
   @Override
-  protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
-    System.out.println("success");
+  protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException, ServletException {
+    String username = extractUsername(authentication);
+    String role = extractRole(authentication);
+
+    String accessToken = jwtUtil.createAccessToken(username, role);
+    String refrestToken = jwtUtil.createRefreshToken(username, role);
+
+    jwtUtil.sendAccessAndRefreshToken(response, accessToken, refrestToken);
+
+    log.info("로그인 성공: {}", username);
+    log.info("Access & refresh 토큰 생성");
   }
 
   @Override
   protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
-    System.out.println("fail");
+    response.setStatus(401);
+  }
+
+  private String extractUsername(Authentication authentication) {
+    CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+    return customUserDetails.getUsername();
+  }
+
+  private String extractRole(Authentication authentication) {
+    Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+    Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+    GrantedAuthority auth = iterator.next();
+    String role = auth.getAuthority();
+    return role;
   }
 }

--- a/backend/src/main/java/com/ttogal/common/util/JwtUtil.java
+++ b/backend/src/main/java/com/ttogal/common/util/JwtUtil.java
@@ -1,0 +1,86 @@
+package com.ttogal.common.util;
+
+
+import io.jsonwebtoken.Jwts;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+  private SecretKey secretKey;
+  @Value("${jwt.access.expiration}")
+  private Long accessTokenExpirationPeriod;
+
+  @Value("${jwt.refresh.expiration}")
+  private Long refreshTokenExpirationPeriod;
+
+  @Value("${jwt.access.header}")
+  private String accessHeader;
+
+  @Value("${jwt.refresh.header}")
+  private String refreshHeader;
+
+  private static final String BEARER = "Bearer ";
+
+  public JwtUtil(@Value("${jwt.secretKey}")String secret){
+    this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+  }
+
+  public String getUsername(String token){
+    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+  }
+
+  public String getRole(String token){
+    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+  }
+
+  public Boolean isTokenExpired(String token){
+    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+  }
+
+  public String createAccessToken(String username, String role) {
+  return Jwts.builder()
+          .claim("category","AccessToken")
+          .claim("username",username)
+          .claim("role",role)
+          .issuedAt(new Date(System.currentTimeMillis()))
+          .expiration(new Date(System.currentTimeMillis()+accessTokenExpirationPeriod))
+          .signWith(secretKey)
+          .compact();
+  }
+
+  public String createRefreshToken(String username, String role) {
+    return Jwts.builder()
+            .claim("category","RefrestToken")
+            .claim("username",username)
+            .claim("role",role)
+            .issuedAt(new Date(System.currentTimeMillis()))
+            .expiration(new Date(System.currentTimeMillis()+refreshTokenExpirationPeriod))
+            .compact();
+  }
+
+  public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
+    response.setStatus(HttpServletResponse.SC_OK);
+    setAccessTokenHeader(response,accessToken);
+    setRefreshTokenCookie(response,refreshToken);
+  }
+
+  private void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
+  response.addHeader(accessHeader, BEARER + accessToken);
+  }
+  private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+    Cookie cookie = new Cookie(refreshHeader, refreshToken);
+    cookie.setHttpOnly(true);
+    cookie.setSecure(true);
+    cookie.setPath("/");
+    cookie.setMaxAge((int) (refreshTokenExpirationPeriod / 1000));
+    response.addCookie(cookie);
+  }
+}

--- a/backend/src/main/java/com/ttogal/common/util/JwtUtil.java
+++ b/backend/src/main/java/com/ttogal/common/util/JwtUtil.java
@@ -1,6 +1,7 @@
 package com.ttogal.common.util;
 
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -34,15 +35,23 @@ public class JwtUtil {
   }
 
   public String getUsername(String token){
-    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+    return getPayload(token).get("username", String.class);
   }
 
   public String getRole(String token){
-    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    return getPayload(token).get("role", String.class);
   }
 
   public Boolean isTokenExpired(String token){
-    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    return getPayload(token).getExpiration().before(new Date());
+  }
+
+  private Claims getPayload(String token) {
+    return Jwts.parser()
+            .verifyWith(secretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
   }
 
   public String createAccessToken(String username, String role) {


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #18 

## 📌 작업 사항 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
 1. 암호화 키 저장
 2. JWT 발급 및 검증 클래스인 JwtUtil 클래스 생성
 3. 발급&검증 메소드 구현
 4.  swagger 테스트

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1.  서버로 들어오는 모든 요청을 가로채 요청 헤더에 있는 token을 검증하고 검증에 성공하면 SecurityContextHolder에 등록하는 JwtFilter 클래스 개발
2. secret key를 이용해 access&refresh token을 발급하고 token을 판독하는 JwtUtil 클래스 개발
3. LoginFilter에 attemptAuthentication 메소드의 결과(인증 실패, 성공)에 따라 적절히 응답해주는 메소드 개발(successfulAuthentication,unsuccessfulAuthentication )
4. jwt 의존성 추가
5.  DB 기반 유저 조회하는 CustomUserDetailsService 구현
6. SecurityConfig 에서 JwtFilter에 JwtUtil 주입하고, 해당 JwtFilter를 빈으로 등록
7.  UserController에 테스트를 위한 임시 api메소드 추가 (/api/v1/users/{userId})

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
1. 오타 수정
2. 중복 로직을 별도의 메소드로 분리함으로써 가독성& 유지보수성 향상

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 테스트 관련
1. /api/v1/users/{userId} 경로는 인증을 완료한 사용자만 접근가능하도록 구현했습니다. 따라서 인증하지 않고 요청하면 아래처럼 403에러가 뜹니다. 
![image](https://github.com/user-attachments/assets/955950a3-9b07-48bd-88b8-a49abeb9f0b0)
![image](https://github.com/user-attachments/assets/8af2eefc-d9f5-446a-b3b3-9d427a505127)
4. 인증을 위해 아래처럼 로그인을 진행하여 성공하면, response header에 jwt가 반환됩니다. 
![image](https://github.com/user-attachments/assets/6376a249-b6f2-4ed6-a737-b202bbad07c1)
![image](https://github.com/user-attachments/assets/3ded0d33-e9fd-40dd-b00d-47523e1ffcaa)
5. 이제 매 요청마다 해당 토큰을 request header에 붙여서 요청을 보내기 위해 swagger에서 다음과 같이 설정합니다.
![image](https://github.com/user-attachments/assets/0687f195-51bb-4c25-bea0-a63430a2334a)
![image](https://github.com/user-attachments/assets/36e14a8f-5930-4bb0-89a9-3af2125fa243)

6. 다시 /api/v1/users/{userId} 경로로 요청을 보내면 인증이 완료된 사용자임을 확인하고 성공응답을 반환합니다. 
![image](https://github.com/user-attachments/assets/5d36fdfc-08b0-4d13-b2bf-dbac5813aa63)
