### PR TITLE
[Feat/#11] 초기 ERD를 기반으로 엔티티와 리포지토리 생성

### DIFF
--- a/backend/src/main/java/com/ttogal/common/entity/BaseEntity.java
+++ b/backend/src/main/java/com/ttogal/common/entity/BaseEntity.java
@@ -1,0 +1,31 @@
+package com.ttogal.common.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/ttogal/domain/album/entity/Album.java
+++ b/backend/src/main/java/com/ttogal/domain/album/entity/Album.java
@@ -1,0 +1,31 @@
+package com.ttogal.domain.album.entity;
+
+import com.ttogal.common.entity.BaseEntity;
+import com.ttogal.domain.album.entity.constant.AlbumType;
+import com.ttogal.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "album")
+@Getter
+public class Album extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long albumId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AlbumType type;
+
+}

--- a/backend/src/main/java/com/ttogal/domain/album/entity/constant/AlbumType.java
+++ b/backend/src/main/java/com/ttogal/domain/album/entity/constant/AlbumType.java
@@ -1,0 +1,5 @@
+package com.ttogal.domain.album.entity.constant;
+
+public enum AlbumType {
+    PERSONAL, SHARED
+}

--- a/backend/src/main/java/com/ttogal/domain/album/repository/AlbumRepository.java
+++ b/backend/src/main/java/com/ttogal/domain/album/repository/AlbumRepository.java
@@ -1,0 +1,7 @@
+package com.ttogal.domain.album.repository;
+
+import com.ttogal.domain.album.entity.Album;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlbumRepository extends JpaRepository<Album, Long> {
+}

--- a/backend/src/main/java/com/ttogal/domain/albumItem/entity/AlbumItem.java
+++ b/backend/src/main/java/com/ttogal/domain/albumItem/entity/AlbumItem.java
@@ -1,0 +1,33 @@
+package com.ttogal.domain.albumItem.entity;
+
+import com.ttogal.domain.album.entity.Album;
+import com.ttogal.domain.restaurant.entity.Restaurant;
+import com.ttogal.domain.review.entity.Review;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Table(name = "albumitem")
+@Getter
+public class AlbumItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "album_item_id")
+    private Long albumItemId;
+
+    @ManyToOne
+    @JoinColumn(name = "restaurant_id", nullable = false)
+    private Restaurant restaurant;
+
+    @ManyToOne
+    @JoinColumn(name = "album_id", nullable = false)
+    private Album album;
+
+    @ManyToOne
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
+
+    @Column(name = "is_public", columnDefinition = "TINYINT(1) DEFAULT 1")
+    private Boolean isPublic = true;
+}

--- a/backend/src/main/java/com/ttogal/domain/albumItem/repository/AlbumItemRepository.java
+++ b/backend/src/main/java/com/ttogal/domain/albumItem/repository/AlbumItemRepository.java
@@ -1,0 +1,8 @@
+package com.ttogal.domain.albumItem.repository;
+
+import com.ttogal.domain.albumItem.entity.AlbumItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlbumItemRepository extends JpaRepository<AlbumItem, Long> {
+
+}

--- a/backend/src/main/java/com/ttogal/domain/bookmark/entity/Bookmark.java
+++ b/backend/src/main/java/com/ttogal/domain/bookmark/entity/Bookmark.java
@@ -1,0 +1,29 @@
+package com.ttogal.domain.bookmark.entity;
+
+import com.ttogal.common.entity.BaseEntity;
+import com.ttogal.domain.restaurant.entity.Restaurant;
+import com.ttogal.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Table(name = "bookmark")
+@Getter
+public class Bookmark extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long bookmarkId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "restaurant_id", nullable = false)
+    private Restaurant restaurant;
+
+    @Column(nullable = false, columnDefinition = "TINYINT(1) DEFAULT 0")
+    private Boolean isFavorite = false;
+
+}

--- a/backend/src/main/java/com/ttogal/domain/bookmark/repository/BookMarkRepository.java
+++ b/backend/src/main/java/com/ttogal/domain/bookmark/repository/BookMarkRepository.java
@@ -1,0 +1,8 @@
+package com.ttogal.domain.bookmark.repository;
+
+import com.ttogal.domain.bookmark.entity.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookMarkRepository extends JpaRepository<Bookmark, Long> {
+
+}

--- a/backend/src/main/java/com/ttogal/domain/category/entity/Category.java
+++ b/backend/src/main/java/com/ttogal/domain/category/entity/Category.java
@@ -1,0 +1,27 @@
+package com.ttogal.domain.category.entity;
+
+import com.ttogal.domain.album.entity.Album;
+import com.ttogal.domain.restaurant.entity.Restaurant;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Table(name = "category")
+@Getter
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long CategoryId;
+
+    @ManyToOne
+    @JoinColumn(name = "restaurant_id", nullable = false)
+    private Restaurant restaurant;
+
+    @ManyToOne
+    @JoinColumn(name = "album_id", nullable = false)
+    private Album album;
+
+    @Column(unique = true, nullable = false)
+    private String name;
+}

--- a/backend/src/main/java/com/ttogal/domain/category/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/ttogal/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package com.ttogal.domain.category.repository;
+
+import com.ttogal.domain.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+}

--- a/backend/src/main/java/com/ttogal/domain/file/entity/File.java
+++ b/backend/src/main/java/com/ttogal/domain/file/entity/File.java
@@ -1,0 +1,44 @@
+package com.ttogal.domain.file.entity;
+
+import com.ttogal.common.entity.BaseEntity;
+import com.ttogal.domain.bookmark.entity.Bookmark;
+import com.ttogal.domain.restaurant.entity.Restaurant;
+import com.ttogal.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Table(name = "file")
+@Getter
+public class File extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long fileId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "restaurant_id", nullable = false)
+    private Restaurant restaurant;
+
+    @ManyToOne
+    @JoinColumn(name = "bookmark_id", nullable = false)
+    private Bookmark bookmark;
+
+    @Column(nullable = false)
+    private String originalFilename;
+
+    @Column(nullable = false)
+    private String storeFilename;
+
+    @Column(nullable = false)
+    private String filePath;
+
+    @Column(nullable = false)
+    private Long fileSize;
+
+}
+

--- a/backend/src/main/java/com/ttogal/domain/file/repository/FileRepository.java
+++ b/backend/src/main/java/com/ttogal/domain/file/repository/FileRepository.java
@@ -1,0 +1,8 @@
+package com.ttogal.domain.file.repository;
+
+import com.ttogal.domain.file.entity.File;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileRepository extends JpaRepository<File,Long> {
+
+}

--- a/backend/src/main/java/com/ttogal/domain/restaurant/entity/Restaurant.java
+++ b/backend/src/main/java/com/ttogal/domain/restaurant/entity/Restaurant.java
@@ -1,0 +1,33 @@
+package com.ttogal.domain.restaurant.entity;
+
+import com.ttogal.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "restaurant")
+@Getter
+public class Restaurant extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long restaurantId;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String subtitle;
+
+    @Column(nullable = false, precision = 10, scale = 8)
+    private BigDecimal latitude;
+
+    @Column(nullable = false, precision = 11, scale = 8)
+    private BigDecimal longitude;
+
+    private String openingHours;
+
+    private String mainMenu;
+}

--- a/backend/src/main/java/com/ttogal/domain/restaurant/repository/RestaurantRepository.java
+++ b/backend/src/main/java/com/ttogal/domain/restaurant/repository/RestaurantRepository.java
@@ -1,0 +1,8 @@
+package com.ttogal.domain.restaurant.repository;
+
+import com.ttogal.domain.restaurant.entity.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+
+}

--- a/backend/src/main/java/com/ttogal/domain/review/entity/Review.java
+++ b/backend/src/main/java/com/ttogal/domain/review/entity/Review.java
@@ -1,0 +1,35 @@
+package com.ttogal.domain.review.entity;
+
+import com.ttogal.common.entity.BaseEntity;
+import com.ttogal.domain.restaurant.entity.Restaurant;
+import com.ttogal.domain.review.entity.constant.ReviewKeyword;
+import com.ttogal.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Table(name = "review")
+@Getter
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reviewId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "restaurant_id", nullable = false)
+    private Restaurant restaurant;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReviewKeyword keywords;
+
+}
+

--- a/backend/src/main/java/com/ttogal/domain/review/entity/constant/ReviewKeyword.java
+++ b/backend/src/main/java/com/ttogal/domain/review/entity/constant/ReviewKeyword.java
@@ -1,0 +1,20 @@
+package com.ttogal.domain.review.entity.constant;
+
+public enum ReviewKeyword {
+    AMAZING("😢 인생 맛집이에요!!! 무조건 재방문 예정"),
+    GOOD("😆 꽤 맛있었어요! 재방문 할 것 같아요"),
+    NOT_BAD("😉 낫배드~ 괜찮았어요"),
+    SO_SO("😥 그냥 그랬어요.. 재방문은 딱히.."),
+    BAD("😡 최악!!");
+
+    private final String description;
+
+    ReviewKeyword(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}
+

--- a/backend/src/main/java/com/ttogal/domain/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/ttogal/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,8 @@
+package com.ttogal.domain.review.repository;
+
+import com.ttogal.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review,Long> {
+
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b28efd24-a71d-43c0-9843-61a5a5ec92a6)

초기 ERD를 기반으로 엔티티, 연관관계, 리포지토리 구성하였습니다.

수정된 내용 및 말씀드리고 싶은 내용
<1>
Restaurant latitude, longtitude 관련
1. BigDecimal 사용 VS 2. Double 또는 Float 사용 고민하였는데, BigDecimal로 설정하는게 낫다고 생각하였습니다.

1. BigDecimal 사용
* 장점: 정밀도(precision)와 소수점(scale)을 명확히 설정할 수 있어서 부동소수점 오차를 피할 수 있음.
* 단점: 성능 저하 및 코드 약간 복잡

2. Double 또는 Float 사용
* 장점:  성능 빠르고 코드 작성 간결
* 단점: 부동소수점 특성상 미세한 오차가 발생 가능성 존재


=>  BigDecimal 설정한 이유 
: 위치 API 관련해서 아무래도 소수점으로 처리해야 되다 보니 연결성을 고려해 정밀도가 높은 BigDecimal를 설정

<2>
Reivew에서 키워드 같은 부분을 ENUM타입으로 따로 빼주었습니다. (ReviewKeyword 참조)

<3> 
Album -> Review 1대 다 단방향 연관관계 추가하였습니다. 저번 회의에서 앨범에서 리뷰를 작성한다고 하셔서요

+)
일단 단방향으로 구축 후 확장시 생각을 해봐야 할 것 같습니다 ! 아직 초기 MVP라 지금 양방향 연관관계 구축하면 꼬일 것 같아서요!